### PR TITLE
SMP3-36 Paginar listado de usuarios

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -27,12 +27,48 @@ class UserController extends Controller
         }
     }
 
-    public function index(){
-        $adminId = Role::where("name","ADMIN")->first()->id;
-        if (auth()->check() && auth()->user()->role_id == $adminId){
-            $users = User::all();
-            return response()->json($users);
-        } else{
+    public function index(Request $request)
+    {
+        $adminId = Role::where("name", "ADMIN")->first()->id;
+        if (auth()->check() && auth()->user()->role_id == $adminId) {
+
+            // Obtener el término de búsqueda del parámetro de consulta ?search
+            $searchTerm = $request->query('search', '');
+
+            // Construir una consulta de búsqueda si se proporciona un término de búsqueda
+            $query = User::query();
+            if ($searchTerm !== '') {
+                $query->where('name', 'like', '%' . $searchTerm . '%')
+                    ->orWhere('last_name', 'like', '%' . $searchTerm . '%')
+                    ->orWhere('email', 'like', '%' . $searchTerm . '%');
+            }
+
+            // Paginar los usuarios 
+            $users = $query->paginate(10);
+
+            // Obtener la URL de la página anterior
+            $prevPageUrl = $users->previousPageUrl();
+
+            // Obtener la URL de la página siguiente
+            $nextPageUrl = $users->nextPageUrl();
+
+            // Construir la respuesta JSON condicionalmente
+            $response = [
+                'data' => $users->items(),
+            ];
+
+            // Agregar las URLs solo si no son nulas
+            if ($prevPageUrl !== null) {
+                $response['prev_page_url'] = $prevPageUrl;
+            }
+
+            if ($nextPageUrl !== null) {
+                $response['next_page_url'] = $nextPageUrl;
+            }
+
+            return response()->json($response);
+            
+        } else {
             return response()->json(['error' => 'No tienes acceso a este endpoint']);
         }
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -35,7 +35,7 @@ class UserController extends Controller
             // Obtener el término de búsqueda del parámetro de consulta ?search
             $searchTerm = $request->query('search', '');
 
-            // Construir una consulta de búsqueda si se proporciona un término de búsqueda
+            // Obtener una consulta de búsqueda si se proporciona un término de búsqueda
             $query = User::query();
             if ($searchTerm !== '') {
                 $query->where('name', 'like', '%' . $searchTerm . '%')
@@ -52,12 +52,12 @@ class UserController extends Controller
             // Obtener la URL de la página siguiente
             $nextPageUrl = $users->nextPageUrl();
 
-            // Construir la respuesta JSON condicionalmente
+            // Obtener la respuesta JSON
             $response = [
                 'data' => $users->items(),
             ];
 
-            // Agregar las URLs solo si no son nulas
+            // Agregar las URLs si no son nulas
             if ($prevPageUrl !== null) {
                 $response['prev_page_url'] = $prevPageUrl;
             }

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -18,7 +18,7 @@ class Account extends Model
         'deleted',
     ];
 
-    protected $hidden = ['created_at', 'updated_at'];
+    protected $hidden = ['created_at', 'updated_at', 'user_id'];
 
     protected $with = ['user'];
 

--- a/app/Models/FixedTerm.php
+++ b/app/Models/FixedTerm.php
@@ -18,7 +18,7 @@ class FixedTerm extends Model
         'closed_at'
     ];
 
-    protected $hidden = ['created_at', 'updated_at'];
+    protected $hidden = ['created_at', 'updated_at', 'account_id'];
 
     protected $with = ['account'];
 

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -13,7 +13,7 @@ class Transaction extends Model
 
     protected $fillable = ['amount', 'type', 'description', 'account_id', 'transaction_date'];
 
-    protected $hidden = ['created_at', 'updated_at'];
+    protected $hidden = ['created_at', 'updated_at', 'account_id'];
 
     protected $with = ['account'];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,7 +36,8 @@ class User extends Authenticatable implements JWTSubject
         'password',
         'remember_token',
         'created_at',
-        'updated_at'
+        'updated_at',
+        'role_id'
     ];
 
     protected $with = ['role'];

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,13 +20,13 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::middleware(['api', 'auth:api'])->group(function () {
+    // Rutas para auth
     Route::prefix('auth')->group(function () {
         Route::post('register', [AuthController::class, 'register'])->name('auth.registro')->withoutMiddleware(['auth:api']);
         Route::post('login', [AuthController::class, 'login'])->withoutMiddleware(['auth:api']);
     });
 
     // Rutas para accounts
-
     Route::prefix('accounts')->group(function () {
         Route::get('balance', [AccountController::class, 'showBalance']);
         Route::get('{id}', [AccountController::class, 'show']);
@@ -40,8 +40,10 @@ Route::middleware(['api', 'auth:api'])->group(function () {
         Route::delete('{id}', [UserController::class, 'destroy']);
     });
 
-
-    Route::post('fixed_terms', [FixedTermController::class, 'store']);
+    // Rutas para fixed_terms
+    Route::prefix('fixed_terms')->group(function () {
+        Route::post('/', [FixedTermController::class, 'store']);
+    });
 
     // Rutas para transactions
     Route::prefix('transactions')->group(function () {
@@ -51,6 +53,5 @@ Route::middleware(['api', 'auth:api'])->group(function () {
         Route::patch('{id}', [TransactionController::class, 'edit']);
         Route::get('/', [TransactionController::class, 'listTransactions']);
         Route::get('/{id}', [TransactionController::class, 'showTransaction']);
-
     });
 });


### PR DESCRIPTION
## Ticket {#SMP3-36}

COMO usuario administrador
QUIERO visualizar el listado de usuarios paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:

- Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. 
- En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). 
- La página actual se obtendrá del parámetro de query ?page.

Cada método, parámetro y funcionalidad debe estar documentado

### RESUMEN
- Se modifican atributos ocultos de los modelos.
- Se modifica la función `index()` del `UserController.php`:
  - Se agrega paginado para el listado de usuarios de a 10.
  - Se agrega soporte para querys de búsqueda para los campos `name`, `last_name` y `email`.

### ¿CÓMO FUE TESTEADO?
Se hizo testing en Postman apuntando a la ruta GET `/api/users` con el token de autenticación obtenido en el login.

#### Screenshots:

![image](https://github.com/alkemyTech/MSM-PHP-T3/assets/101674182/d5f6eb3a-4f2e-4e0f-bed3-3b8ac4841ed1)
![image](https://github.com/alkemyTech/MSM-PHP-T3/assets/101674182/912736d4-8386-4e1f-94d9-849c68443632)
![image](https://github.com/alkemyTech/MSM-PHP-T3/assets/101674182/623dd74b-1143-444c-bee4-22b5dfceea48)

### CHECKLIST
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added the new resource in the Postman Collection file.
